### PR TITLE
Show the navigation bar in small devices

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,10 +1,8 @@
-<div class="nav-collapse collapse">
-  <ul class="nav">
-    <li><a href="index.html">Home</a></li>
-    <li><a href="news/index.html">News</a></li>
-    <li><a href="blog/index.html">Blog</a></li>
-    <li><a href="documentation/index.html">Documentation</a></li>
-    <li><a href="contacts/index.html">Contacts</a></li>
-    <li><a href="http://quattor.sourceforge.net">Old web site</a></li>
-  </ul>
-</div>
+<ul class="nav">
+  <li><a href="index.html">Home</a></li>
+  <li><a href="news/index.html">News</a></li>
+  <li><a href="blog/index.html">Blog</a></li>
+  <li><a href="documentation/index.html">Documentation</a></li>
+  <li><a href="contacts/index.html">Contacts</a></li>
+  <li><a href="http://quattor.sourceforge.net">Old web site</a></li>
+</ul>


### PR DESCRIPTION
That is, remove Bootstrap's `collapse` attribute from it.
