### PR TITLE
Replace default font

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,18 +2,16 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Quattor | {{ page.title }}</title>
   <base href="{{ site.baseurl }}" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css"
-	  href="bootstrap/css/bootstrap.min.css" media="screen" />
-    <link rel="stylesheet" type="text/css" media="screen"
-	  href="bootstrap/css/pygments.css"/>
-    <link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" type="text/css" href="bootstrap/css/bootstrap.min.css" media="screen" />
+  <link rel="stylesheet" type="text/css" media="screen" href="bootstrap/css/pygments.css"/>
+  <link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
   <style type="text/css">
     @import url(http://fonts.googleapis.com/css?family=Lato:400);
     body {
-    padding-top: 60px;
-    padding-bottom: 40px;
-    font-family: 'Lato', 'Helvetica', sans-serif;
+      padding-top: 60px;
+      padding-bottom: 40px;
+      font-family: 'Lato', 'Helvetica', sans-serif;
     }
   </style>
   <link rel="publisher" href="https://plus.google.com/106108753304191902209" />


### PR DESCRIPTION
Switch page font to the GWF Lato, which gives the pages a fresher look and complements the Quattor logotype nicely.
