### PR TITLE
Add link to release tags in config-modules-core-templates

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -6,3 +6,4 @@ title: downloads
 * RPM packages are available from our [Yum Repositories](http://yum.quattor.org/).
 * Tarballs, jar files and manuals from [Sourceforge files](http://sourceforge.net/projects/quattor/files/).
 * The standard template library developed by the Quattor Working Group can be checked out from the [LAL SVN server](https://svn.lal.in2p3.fr/LCG/QWG/templates/trunk/).
+* PAN templates for components to match releases are tagged in the [core templates repository](https://github.com/quattor/config-modules-core-templates/releases).


### PR DESCRIPTION
This means no-one should have to be psychic to find them anymore.
