### PR TITLE
Print the modified tag when available.

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -34,9 +34,13 @@
 	</div> <!-- row-fluid -->
 	<div class="page-header row-fluid">
 	  <h1>{{ page.title }}</h1>
-	  <p class="date">{{ page.date | date: "%d %B %Y" }}</p>
+          <div class="span2 date"><p>{{ page.date | date: "%d %B %Y" }}</p></div>
+          {% if page.modified %}
+          <div class="span3 date"><p class="muted">reviewed: {{ page.modified | date: "%d %B %Y"}}</p>
+          </div>
+          {% endif %}
 	  {% if page.author %}
-	  <div class="author">{{ page.author }}</div>
+	  <div class="author span12">{{ page.author }}</div>
 	  {% endif %}
 	</div> <!-- page-header row-fluid -->
 	<div class="row-fluid">


### PR DESCRIPTION
Some pages undergo many revisions.  They were first written a long time
ago and are buried down in the index, but we have reviewed them to
reflect the reality of the latest releases.  An example of this is the
Aquilon documentation.

Since we don't want to break existing links, we need to inform that the
page is still current.  A "modified" tag in the page metadata, and
displaying it on the header is the best I can think of at this time.
