### PR TITLE
Disable pagination

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-paginate: 10000
 baseurl: http://quattor.github.com/
 pygments: true
 markdown: redcarpet


### PR DESCRIPTION
Our index isn't compatible, so it doesn't work anyway and causes warning messages.
