### PR TITLE
Add disqus comments box to end of article layout

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,3 +1,6 @@
+---
+comments: true
+---
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
@@ -27,7 +30,23 @@
         {{ page.content | markdownify }}
       </div> <!-- row  -->
     </div>
-
+    {% if page.comments %}
+    <hr>
+    <div class="container">
+      <div id="disqus_thread"></div>
+      <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES * * */
+        var disqus_shortname = 'quattor'; // required: replace example with your forum shortnam
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+          dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();       </script>
+      <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+      <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    </div>
+    {% endif %}
     {% include footer.html %}
   </body>
 </html>


### PR DESCRIPTION
For now this is enabled for all article types, we can always change that later if we want.

Fixes #68.
