### PR TITLE
Use rouge instead of Pygments for easier page development on Windows

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 baseurl: http://quattor.github.com/
-pygments: true
+pygments: false
+rouge: true
 markdown: redcarpet


### PR DESCRIPTION
I've been struggling to get Jekyll working on Windows because it needs Pygments (for syntax highlighting) which is in fact a Python module and the Ruby-Python mix seems quite difficult on Windows. I followed dozen of recipes without any success. I found that rouge, a pure-Ruby replacement, could be used instead of Python. This fixes all my problems and the site displays perfectly (same result as with Pygments on GitHub). I plan to write a short documentation about that to avoid others the same nightmare... And I agree with James that we need web site contributors to run Jekyll before sending pull requests as Jekyll as some differences with markdown accepted in other places on GitHub.

I could have my own version of _config.yml but with the risk of commiting it at some point... I'd suggest switching to rouge on the web site. I could not find an explicit mention that this is supported by GitHub but as Jekyll is developped by GitHub, I cannot imagine this is not the case.

I don't see other ways of testing that merging this pull request and revert it in case of problems...

BTW, I should have mentionned that if you have Jekyll already installed and want to test rouge, this is as easy as doing:

```
gem install rouge
```

Feedback/comments welcome!

Michel
