### PR TITLE
Implementation of TOC for articles (blog, news, documentation).

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 baseurl: http://quattor.github.com/
 pygments: true
 markdown: redcarpet
+redcarpet:
+    extensions: [with_toc_data]

--- a/_config_rouge.yml
+++ b/_config_rouge.yml
@@ -2,3 +2,6 @@ baseurl: http://quattor.github.com/
 pygments: false
 rouge: true
 markdown: redcarpet
+redcarpet:
+    extensions: [with_toc_data]
+    

--- a/_config_rouge_v2.yml
+++ b/_config_rouge_v2.yml
@@ -1,3 +1,6 @@
 baseurl: http://quattor.github.com/
 highlighter: rouge
 markdown: redcarpet
+redcarpet:
+    extensions: [with_toc_data]
+    

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,3 +7,9 @@
 <!-- Placed at the end of the document so the pages load faster -->
 <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="bootstrap/js/bootstrap.min.js"></script>
+<script src="js/toc.js"></script>
+<script type="text/javascript">
+	$(document).ready(function() {
+	    $('.toc').toc();
+	});
+</script>    

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -26,6 +26,7 @@ comments: true
         </dl>
       </div> <!-- row -->
       <hr>
+      <div class="toc"></div>
       <div class="row">
         {{ page.content | markdownify }}
       </div> <!-- row  -->
@@ -47,6 +48,7 @@ comments: true
       <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
     </div>
     {% endif %}
+    
     {% include footer.html %}
   </body>
 </html>

--- a/js/toc.js
+++ b/js/toc.js
@@ -1,0 +1,60 @@
+// https://github.com/ghiculescu/jekyll-table-of-contents
+(function($){
+  $.fn.toc = function(options) {
+    var defaults = {
+      noBackToTopLinks: false,
+      title: '<i>Jump to...</i>',
+      listType: 'ol', // values: [ol|ul]
+      showSpeed: 'slow'
+    },
+    settings = $.extend(defaults, options);
+    
+    var headers = $('h1, h2, h3, h4, h5, h6').filter(function() {
+      // get all headers with an ID
+      return this.id;
+    }), output = $(this);
+    if (!headers.length || headers.length < 3 || !output.length) {
+      return;
+    }
+    
+    var get_level = function(ele) { return parseInt(ele.nodeName.replace("H", ""), 10); }
+    var highest_level = headers.map(function(_, ele) { return get_level(ele); }).get().sort()[0];
+    var return_to_top = '<i class="icon-arrow-up back-to-top"> </i>';
+    var href = $(location).attr('href');
+    
+    var level = get_level(headers[0]),
+      this_level,
+      html = settings.title + " <"+settings.listType+">";
+    headers.on('click', function() {
+      if (!settings.noBackToTopLinks) {
+        window.location.hash = this.id;
+      }
+    })
+    .addClass('clickable-header')
+    .each(function(_, header) {
+      this_level = get_level(header);
+      if (!settings.noBackToTopLinks && this_level === highest_level) {
+        $(header).addClass('top-level-header').after(return_to_top);
+      }
+      if (this_level === level) // same level as before; same indenting
+        html += "<li><a href='" + href + "#" + header.id + "'>" + header.innerHTML + "</a>";
+      else if (this_level < level) // higher level than before; end parent ol
+        html += "</li></"+settings.listType+"></li><li><a href='" + href + "#" + header.id + "'>" + header.innerHTML + "</a>";
+      else if (this_level > level) // lower level than before; expand the previous to contain a ol
+        html += "<"+settings.listType+"><li><a href='" + href + "#" + header.id + "'>" + header.innerHTML + "</a>";
+      level = this_level; // update for the next one
+    });
+    html += "</"+settings.listType+">";
+    if (!settings.noBackToTopLinks) {
+      $(document).on('click', '.back-to-top', function() {
+        $(window).scrollTop(0);
+        window.location.hash = '';
+      });
+    }
+    if (0 !== settings.showSpeed) {
+      output.hide().html(html).show(settings.showSpeed);
+    } else {
+      output.html(html);
+    }
+  };
+})(jQuery);


### PR DESCRIPTION
Attempt to address #87. Based on:
- https://github.com/ghiculescu/jekyll-table-of-contents
- http://stackoverflow.com/questions/7985081/how-to-deploy-a-jekyll-site-locally-with-css-js-and-background-images-included

Several options available to customize toc() behaviour. In particular we may want to add a yaml option to disable TOC on some pages using the article layout...

In addition we may add a CSS...
