### PR TITLE
Link directly to articles mentioned in introduction

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -8,6 +8,6 @@ title: Documentation
 {% assign category_items = site.categories.documentation %}
 -->
 
-This page contains high-level documentation of the core tools of the Quattor
-Toolkit. People new to Quattor should start with the "Overview" and "Getting
-Started" articles. If you don't find the documentation you need here, tell us!
+This page contains high-level documentation of the core tools of the Quattor Toolkit.
+People new to Quattor should start with the "[Overview](/documentation/2012/06/19/documentation-overview.html)" and "[Getting Started](/documentation/2013/10/01/documentation-getting-started.html)" articles.
+If you don't find the documentation you need here, tell us!


### PR DESCRIPTION
We mention them and then expect people to find the articles themselves, we must have forgotten that this is HTML. Why not be helpful and link to them directly.
