### PR TITLE
Fix instances of malformed HTML

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -33,6 +33,5 @@
       </div> <!-- row  -->
     </div>
     {% include footer.html %}
-    </script>
   </body>
 </html>

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -42,7 +42,6 @@
           {% endfor %}
       </div> <!-- row -->
     </div> <!-- container -->
-
     {% include footer.html %}
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,7 +45,6 @@
         </div>
       </div>
     </div>
-
     {% include footer.html %}
   </body>
 </html>

--- a/_posts/2012-12-15-migrating-to-json-profiles.md
+++ b/_posts/2012-12-15-migrating-to-json-profiles.md
@@ -72,7 +72,7 @@ grep 'profiles/.*xml' /etc/httpd/logs/access_log | grep '10/May/2014:15' | awk '
 **It is strongly recommanded to fix all the problematic nodes before generating only JSON profiles, else you will loose control on these nodes.
 You also need the period to be long enough to allow nodes which are down to get a chance to be restarted, as these nodes will not appear in the `httpd`logs.**
 
-### SCDB
+### Using JSON profiles with SCDB
 
 To generate the JSON format in addition to the XML format, you need to add or edit the
 file `quattor.build.properties` in the root directory of your configuration database (same directory

--- a/_posts/2013-03-27-cleaning-up-packages.md
+++ b/_posts/2013-03-27-cleaning-up-packages.md
@@ -23,7 +23,7 @@ This forced each new service and most upgrades to go through
 time-consuming trial and error cycles: list the expected packages,
 deploy, read the error messages, fix those messages, iterate.
 
-### Fix: Yum
+### Fix: YUM
 
 With the proper configuration, Yum will handle dependencies in the way
 we want them.
@@ -79,7 +79,7 @@ Adding a new RPM to the infrastructure would require:
 
 That's a lot.  Especially if the new RPM is just a version bump.
 
-### Fix: Yum
+### Fix: YUM again
 
 The new workflow is simpler:
 

--- a/_posts/2013-10-18-announcing-13.1.2.md
+++ b/_posts/2013-10-18-announcing-13.1.2.md
@@ -135,7 +135,7 @@ Full Changelog
     * 5d3598b Merge branch 'master' of https://github.com/quattor/configuration-modules-core
     * 68b02e8 Merge branch 'master' of https://github.com/quattor/configuration-modules-core
 * configuration-modules-grid
-    * e8174c5 Remove <repositories> on pom.xml of grid component
+    * e8174c5 Remove &lt;repositories&gt; on pom.xml of grid component
     * f4ea30a Change nexus server from stratuslab-srv01
 * LC
 * ncm-cdispd

--- a/documentation/14.6.0/components/cron/index.md
+++ b/documentation/14.6.0/components/cron/index.md
@@ -167,11 +167,11 @@ None.
 
 ### BUGS
 
-#### Linux
+#### Linux bugs
 
     None known.
 
-#### Solaris
+#### Solaris bugs
 
     Editing the NCM-CRON BEGIN: and/or the NCM-CRON END: tag within a crontab will
     cause unpredictable behaviour. Possible behavours are duplicate entries or

--- a/documentation/14.6.0/components/metaconfig/index.md
+++ b/documentation/14.6.0/components/metaconfig/index.md
@@ -194,7 +194,7 @@ And now, we only have to specify the contents:
     "s1/a" = 42;
     "s2/b" = "hitchicker";
 
-##### And that's it
+##### That's it
 
 That's it!  When you deploy your configuration you should see your
 `/etc/foo.ini` in the correct location.

--- a/documentation/14.6.0/components/useraccess/index.md
+++ b/documentation/14.6.0/components/useraccess/index.md
@@ -11,7 +11,7 @@ The useraccess NCM component allows to manage the different ways an user
 can get into a machine. Currently it configures Kerberos access, SSH
 public keys access and specific services via ACLs.
 
-It is meant to replace (and improve) ncm-access\_control . It provides
+It is meant to replace (and improve) ncm-access_control. It provides
 much cleaner interface, way better documentation and far better
 granularity support. It rocks, really! ;)
 
@@ -20,7 +20,7 @@ that user__
 
 ### BASIC COMPONENT STRUCTURE
 
-Besides the classic component\_structure fields, it provides two more
+Besides the classic component_structure fields, it provides two more
 fields, named `users` and `roles`. `users` will contain the
 authorization information for each user, and `roles` will contain a
 set of credentials for users to accept. Both `users` and `roles`
@@ -44,38 +44,38 @@ user:
     necessary when the change is in a file external to the configuration,
     referred by a URL.
 
-- `/software/components/useraccess/acl`\_services
+- `/software/components/useraccess/acl_services`
 
     List of services that will have ACLs associated to them.
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/kerberos4
+- `/software/components/useraccess/{users,roles}/<id>/kerberos4`
 
     It is a list of the users who can log in using Kerberos v4
     tickets. The contents of this list will be appropriately formatted and
     written into ~/.klogin.
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/kerberos5
+- `/software/components/useraccess/{users,roles}/<id>/kerberos5`
 
     It is a list of the users who can log using Kerberos v5 tickets. The
     contents of this list will be appropriately formatted and written into
     ~/.k5login.
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/ssh\_keys\_urls
+- `/software/components/useraccess/{users,roles}/<id>/ssh_keys_urls`
 
     It is a list containing the __absolute URLs__ where the public keys
     granted to login as this user can be found. The URL can have any
     schema LWP::UserAgent supports, and it has been tested with http://,
     https:// and file:// . Local files are admitted, if wanted.
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/ssh\_keys
+- `/software/components/useraccess/{users,roles}/<id>/ssh_keys`
 
     It is a list containing the __exact lines__ to be added to
-    ~/.ssh/authorized\_keys.
+    ~/.ssh/authorized_keys.
 
-    The preferred way for adding authorized\_keys is ssh\_keys\_urls, but if
+    The preferred way for adding authorized_keys is ssh_keys_urls, but if
     you are happy filling your templates with garbage, serve yourself. :P
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/acls
+- `/software/components/useraccess/{users,roles}/<id>/acls`
 
     It is a list of the ACL-controlled services the user is allowed to log
     in. This only applies to PAM controlled services. SSH is not (not
@@ -83,20 +83,20 @@ user:
 
     __IMPORTANT NOTE__ this will add athe user to the given ACL, but will
     __not__ force the service to use ACLs at all. To do so, add the service
-    to `/software/components/useraccess/acl`\_services .
+    to `/software/components/useraccess/acl_services .`
 
-- `/software/components/useraccess/{users`,roles}/&lt;id&gt;/roles
+- `/software/components/useraccess/{users,roles}/<id>/roles`
 
     List of strings. It contains the lists of roles the user belongs
     to. Roles can be nested.
 
     It is a compile-time error to add an user to a non-existing role.
 
-- `/software/components/useraccess/users`/&lt;id&gt;/managed\_credentials
+- `/software/components/useraccess/users/<id>/managed_credentials`
 
     List of authentication methods the component will configure (and thus,
     fully control) for the user. It is a list of strings, with possible
-    values "ssh\_keys", "kerberos4" and "kerberos5".
+    values "ssh_keys", "kerberos4" and "kerberos5".
 
     It defaults to control all credentials, change it if you want to
     control something by some other means. For instance, CERN uses a
@@ -108,23 +108,23 @@ user:
 Both `kerberos4` and `kerberos5` share the same structure. It
 contains the following fields:
 
-- `/software/components/useraccess`/&lt;id&gt;/kerberosX/realm : mandatory
+- `/software/components/useraccess/<id>/kerberosX/realm` : mandatory
 
     Kerberos' realm for authentication (the part behind the @ in
     .klogin). For instance, CERN.CH .
 
-- `/software/components/useraccess`/&lt;id&gt;/kerberosX/principal :
+- `/software/components/useraccess/<id>/kerberosX/principal` :
 mandatory
 
     Principal identity for the user in the Kerberos ticket server.
 
-- `/software/components/useraccess`/&lt;id&gt;/kerberosX/instance :
+- `/software/components/useraccess/<id>/kerberosX/instance` :
 optional
 
     "Instance" identity for the user. This is a sub-identity, and it's
     optional.
 
-- `/software/components/useraccess`/&lt;id&gt;/kerberosX/host : optional
+- `/software/components/useraccess/<id>/kerberosX/host` : optional
 
     Host from which the ticket must come for this identity. It is
     currently ignored.
@@ -281,4 +281,4 @@ with `passwd -l`. Depending on how you configured SSH, a locked user
 may still be able to log-in with his public key. You can run `ncm-ncd
 --unconfigure useraccess` to temporarily lock all accounts, before
 removing the user's entry from CDB. Or remove manually .k\*login and
-.ssh/authorized\_keys.
+.ssh/authorized_keys.

--- a/documentation/14.8.0/components/accounts/index.md
+++ b/documentation/14.8.0/components/accounts/index.md
@@ -270,4 +270,4 @@ ncm-accounts but by [ncm-authconfig](/documentation/14.8.0/components/authconfig
 
 [ncm-authconfig](/documentation/14.8.0/components/authconfig/index.html)
 
-Luis Fernando Muñoz Mejías <Luis.Fernando.Munoz.M>
+Luis Fernando Muñoz Mejías &lt;Luis.Fernando.Munoz.M&gt;

--- a/documentation/14.8.0/components/chkconfig/index.md
+++ b/documentation/14.8.0/components/chkconfig/index.md
@@ -45,7 +45,7 @@ NCM::chkconfig - NCM chkconfig component
 - `/software/components/chkconfig/service/<service>/off : string ("[0-7]*")`
 - `/software/components/chkconfig/service/<service>/on : string ("[0-7]*")`
 
-    Sets the service <service> on/off on specified run levels. The run
+    Sets the service `<service>` on/off on specified run levels. The run
     levels are specified as string of numbers, the same way as with
     `chkconfig`\-command. If the string is empty, system default is taken
     (see `man chkconfig(8)` for exact details).
@@ -53,7 +53,7 @@ NCM::chkconfig - NCM chkconfig component
 - `/software/components/chkconfig/service/<service>/name : string`
 
     If set, the value is used as the name of the service instead of using the
-    <service> path as a name.
+    `<service>` path as a name.
 
 - `/software/components/chkconfig/service/<service>/reset : string ("[0-7]*")`
 
@@ -115,7 +115,7 @@ None.
 - __reset__ behaviour should check against current config?
 - __startstop__ logic depends on init script, will mindlessly start some services despite them running already
 
-Teemu Sidoroff <Teemu.S>
+Teemu Sidoroff &lt;Teemu.S&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/cron/index.md
+++ b/documentation/14.8.0/components/cron/index.md
@@ -167,11 +167,11 @@ None.
 
 ### BUGS
 
-#### Linux
+#### Linux bugs
 
     None known.
 
-#### Solaris
+#### Solaris bugs
 
     Editing the NCM-CRON BEGIN: and/or the NCM-CRON END: tag within a crontab will
     cause unpredictable behaviour. Possible behavours are duplicate entries or

--- a/documentation/14.8.0/components/cron/index.md
+++ b/documentation/14.8.0/components/cron/index.md
@@ -180,13 +180,13 @@ None.
     Editing BETWEEN the tags will cause the edits to be overwritten the next time
     ncm-cron runs.
 
-Charles Loomis <charles.loomis@cern.ch>
+Charles Loomis &lt;charles.loomis@cern.ch&gt;
 
 S
 
-Guillaume Philippon <>
+Guillaume Philippon
 
-Mark Wilson <Mark.Wilson@MorganStanley.com>
+Mark Wilson &lt;Mark.Wilson@MorganStanley.com&gt;
 
 ### VERSION
 

--- a/documentation/14.8.0/components/directoryservices/index.md
+++ b/documentation/14.8.0/components/directoryservices/index.md
@@ -27,9 +27,7 @@ None.
 
 None known.
 
-Nick Williams <Nick.W>
-
-Nick Williams <Nick.W>
+Nick Williams &lt;Nick.W&gt;
 
 ### VERSION
 

--- a/documentation/14.8.0/components/etcservices/index.md
+++ b/documentation/14.8.0/components/etcservices/index.md
@@ -52,7 +52,7 @@ none.
 
 none known.
 
-Juan.Pelegrin <Juan.P>
+Juan.Pelegrin &lt;Juan.P&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/fstab/index.md
+++ b/documentation/14.8.0/components/fstab/index.md
@@ -23,4 +23,4 @@ https://twiki.cern.ch/twiki/bin/view/FIOgroup/TsiCDBBlockDevices
 
 [ncm-filesystems](/documentation/14.8.0/components/filesystems/index.html)
 
-Luis Fernando Muñoz Mejías, <Luis.Fernando.Munoz.M>
+Luis Fernando Muñoz Mejías, &lt;Luis.Fernando.Munoz.M&gt;

--- a/documentation/14.8.0/components/grub/index.md
+++ b/documentation/14.8.0/components/grub/index.md
@@ -161,7 +161,7 @@ none known.
 
 S
 
-German Cancio <German.Cancio@cern.ch>, Stephen Childs <Stephen.C>
+German Cancio &lt;German.Cancio@cern.ch&gt;, Stephen Childs &lt;Stephen.C&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/interactivelimits/index.md
+++ b/documentation/14.8.0/components/interactivelimits/index.md
@@ -50,7 +50,7 @@ None.
 
 None known.
 
-Vladimir Bahyl <Vladimir.B>
+Vladimir Bahyl &ltVladimir.B&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/iptables/index.md
+++ b/documentation/14.8.0/components/iptables/index.md
@@ -170,11 +170,11 @@ The __"out\_interface"__ define the output interface for the packet.
 
 The __"target"__ define the target for the packet: "log", "accept" or "drop".
 
-#### function add\_rule(<table>, <rule>)
+#### function `add_rule(<table>, <rule>)`
 
 This function add a new entry rule to the resource list
 
-    "/software/components/iptables/<table>/rules"
+    `"/software/components/iptables/<table>/rules"`
 
 ### DEPENDENCIES
 

--- a/documentation/14.8.0/components/mcx/index.md
+++ b/documentation/14.8.0/components/mcx/index.md
@@ -29,9 +29,7 @@ ncm-directoryservices
 
 None known.
 
-Nick Williams <Nick.W>
-
-Nick Williams <Nick.W>
+Nick Williams &lt;Nick.W&gt;
 
 ### VERSION
 

--- a/documentation/14.8.0/components/metaconfig/index.md
+++ b/documentation/14.8.0/components/metaconfig/index.md
@@ -196,7 +196,7 @@ And now, we only have to specify the contents:
     "s1/a" = 42;
     "s2/b" = "hitchicker";
 
-##### And that's it
+##### That's it
 
 That's it!  When you deploy your configuration you should see your
 `/etc/foo.ini` in the correct location.

--- a/documentation/14.8.0/components/metaconfig/index.md
+++ b/documentation/14.8.0/components/metaconfig/index.md
@@ -76,6 +76,7 @@ The following formats my be rendered:
     Uses Perl's [Config::General](https://metacpan.org/pod/Config::General). This leads to configuration files
     similar to this one:
 
+```pan
         <nlist>
           <another nlist>
             scalar value
@@ -85,6 +86,7 @@ The following formats my be rendered:
         list_element 0
         list_element 1
         list_element 2
+```
 
 - tiny
 

--- a/documentation/14.8.0/components/modprobe/index.md
+++ b/documentation/14.8.0/components/modprobe/index.md
@@ -47,7 +47,7 @@ None.
 
 Cannot clean out "install" and "remove" lines again.
 
-Hugo Cacote <Hugo.C>
+Hugo Cacote &lt;Hugo.C&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/network/index.md
+++ b/documentation/14.8.0/components/network/index.md
@@ -90,7 +90,7 @@ Set the behaviour for interface eth\[i\]. This overrides the default setting.
 
 ### CHANNEL BONDING
 
-(see <kernel>/Documentation/networking/bonding.txt for more info on the driver options)
+(see `<kernel>/Documentation/networking/bonding.txt` for more info on the driver options)
 
 To enable channel bonding with quattor using devices eth0 and eth1 to form bond0, proceed as follows:
 

--- a/documentation/14.8.0/components/ntpd/index.md
+++ b/documentation/14.8.0/components/ntpd/index.md
@@ -343,8 +343,8 @@ none known.
 
 S
 
-- Thorsten Kleinwort <Thorsten.Kleinwort@cern.ch>
-- John Monteiro <John.M>
+- Thorsten Kleinwort &lt;Thorsten.Kleinwort@cern.ch&gt;
+- John Monteiro &lt;John.M&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/puppet/index.md
+++ b/documentation/14.8.0/components/puppet/index.md
@@ -47,7 +47,7 @@ The default is
 
 #### `/software/components/puppet/nodefiles`
 
-named list of node specific manifests. The component will run "puppet --apply `/etc/puppet/manifests`/<file>" for each item <file> of the nlist.
+named list of node specific manifests. The component will run "puppet --apply `/etc/puppet/manifests/<file>`" for each item `<file>` of the nlist.
 The parameters of each item are.
 
 - `contents` : string

--- a/documentation/14.8.0/components/spma/ips/index.md
+++ b/documentation/14.8.0/components/spma/ips/index.md
@@ -160,7 +160,7 @@ Solaris:
                              "/software/uninstall");
     "flagfile" = "/var/tmp/spma-run-flag"
 
-Original author: German Cancio <German.C>
+Original author: German Cancio &lt;German.C&gt;
 
 Author of the IPS-based package manager: Mark R. Bannister.
 

--- a/documentation/14.8.0/components/spma/yum/index.md
+++ b/documentation/14.8.0/components/spma/yum/index.md
@@ -155,7 +155,7 @@ This component honors the __\--noaction__ mode.
 The typing of the CDB entries is yet to be done: for now, all of them are
 strings.
 
-Original author: German Cancio <German.C>
+Original author: German Cancio &lt;German.C&gt;
 
 Author of the Yum-based package manager: Luis Fernando Muñoz Mejías
 

--- a/documentation/14.8.0/components/ssh/index.md
+++ b/documentation/14.8.0/components/ssh/index.md
@@ -72,7 +72,7 @@ None.
 
 None known.
 
-Teemu Sidoroff <Teemu.S>
+Teemu Sidoroff &lt;Teemu.S&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/sudo/index.md
+++ b/documentation/14.8.0/components/sudo/index.md
@@ -16,13 +16,13 @@ common users' mistakes.
 
 On top, it provides the following fields:
 
-- `/software/components/sudo/general`\_options : optional
+- `/software/components/sudo/general_options` : optional
 
     It is a list of `structure_sudo_defaults` elements. It sets default
     behaviour either for users or hosts, or for the whole sudo
     application. This structure will be explained later.
 
-- "/software/components/sudo/<user|run\_as|host|cmd>\_aliases :
+- `/software/components/sudo/<user|run_as|host|cmd>_aliases` :
 optional
 
     Named lists of lists of strings containing the alias information.  The

--- a/documentation/14.8.0/components/sysconfig/index.md
+++ b/documentation/14.8.0/components/sysconfig/index.md
@@ -23,7 +23,7 @@ before or after the key-value pair definitions.
     This is an nlist which has the file name (unescaped) as the key, and
     the content information as the value.  The value is an nlist.
 
-- `/software/components/sysconfig/files`/<fname>/
+- `/software/components/sysconfig/files/<fname>/`
 
     This is a nlist containing key-value pairs.  Both are strings.
     There are two special keys "prologue" and "epilogue" which contain

--- a/documentation/14.8.0/components/sysctl/index.md
+++ b/documentation/14.8.0/components/sysctl/index.md
@@ -59,7 +59,7 @@ None.
 
 None known.
 
-Benjamin Chardi <Benjamin.Chardi.M>
+Benjamin Chardi &lt;Benjamin.Chardi.M&gt;
 
 ### SEE ALSO
 

--- a/documentation/14.8.0/components/useraccess/index.md
+++ b/documentation/14.8.0/components/useraccess/index.md
@@ -11,7 +11,7 @@ The useraccess NCM component allows to manage the different ways an user
 can get into a machine. Currently it configures Kerberos access, SSH
 public keys access and specific services via ACLs.
 
-It is meant to replace (and improve) ncm-access\_control . It provides
+It is meant to replace (and improve) ncm-access_control. It provides
 much cleaner interface, way better documentation and far better
 granularity support. It rocks, really! ;)
 
@@ -20,7 +20,7 @@ that user__
 
 ### BASIC COMPONENT STRUCTURE
 
-Besides the classic component\_structure fields, it provides two more
+Besides the classic component_structure fields, it provides two more
 fields, named `users` and `roles`. `users` will contain the
 authorization information for each user, and `roles` will contain a
 set of credentials for users to accept. Both `users` and `roles`
@@ -44,38 +44,38 @@ user:
     necessary when the change is in a file external to the configuration,
     referred by a URL.
 
-- `/software/components/useraccess/acl`\_services
+- `/software/components/useraccess/acl_services`
 
     List of services that will have ACLs associated to them.
 
-- `/software/components/useraccess/{users`,roles}/<id>/kerberos4
+- `/software/components/useraccess/{users,roles}/<id>/kerberos4`
 
     It is a list of the users who can log in using Kerberos v4
     tickets. The contents of this list will be appropriately formatted and
     written into ~/.klogin.
 
-- `/software/components/useraccess/{users`,roles}/<id>/kerberos5
+- `/software/components/useraccess/{users,roles}/<id>/kerberos5`
 
     It is a list of the users who can log using Kerberos v5 tickets. The
     contents of this list will be appropriately formatted and written into
     ~/.k5login.
 
-- `/software/components/useraccess/{users`,roles}/<id>/ssh\_keys\_urls
+- `/software/components/useraccess/{users,roles}/<id>/ssh_keys_urls`
 
     It is a list containing the __absolute URLs__ where the public keys
     granted to login as this user can be found. The URL can have any
     schema LWP::UserAgent supports, and it has been tested with http://,
     https:// and file:// . Local files are admitted, if wanted.
 
-- `/software/components/useraccess/{users`,roles}/<id>/ssh\_keys
+- `/software/components/useraccess/{users,roles}/<id>/ssh_keys`
 
     It is a list containing the __exact lines__ to be added to
-    ~/.ssh/authorized\_keys.
+    ~/.ssh/authorized_keys.
 
-    The preferred way for adding authorized\_keys is ssh\_keys\_urls, but if
+    The preferred way for adding authorized_keys is ssh_keys_urls, but if
     you are happy filling your templates with garbage, serve yourself. :P
 
-- `/software/components/useraccess/{users`,roles}/<id>/acls
+- `/software/components/useraccess/{users,roles}/<id>/acls`
 
     It is a list of the ACL-controlled services the user is allowed to log
     in. This only applies to PAM controlled services. SSH is not (not
@@ -83,20 +83,20 @@ user:
 
     __IMPORTANT NOTE__ this will add athe user to the given ACL, but will
     __not__ force the service to use ACLs at all. To do so, add the service
-    to `/software/components/useraccess/acl`\_services .
+    to `/software/components/useraccess/acl_services .`
 
-- `/software/components/useraccess/{users`,roles}/<id>/roles
+- `/software/components/useraccess/{users,roles}/<id>/roles`
 
     List of strings. It contains the lists of roles the user belongs
     to. Roles can be nested.
 
     It is a compile-time error to add an user to a non-existing role.
 
-- `/software/components/useraccess/users`/<id>/managed\_credentials
+- `/software/components/useraccess/users/<id>/managed_credentials`
 
     List of authentication methods the component will configure (and thus,
     fully control) for the user. It is a list of strings, with possible
-    values "ssh\_keys", "kerberos4" and "kerberos5".
+    values "ssh_keys", "kerberos4" and "kerberos5".
 
     It defaults to control all credentials, change it if you want to
     control something by some other means. For instance, CERN uses a
@@ -108,23 +108,23 @@ user:
 Both `kerberos4` and `kerberos5` share the same structure. It
 contains the following fields:
 
-- `/software/components/useraccess`/<id>/kerberosX/realm : mandatory
+- `/software/components/useraccess/<id>/kerberosX/realm` : mandatory
 
     Kerberos' realm for authentication (the part behind the @ in
     .klogin). For instance, CERN.CH .
 
-- `/software/components/useraccess`/<id>/kerberosX/principal :
+- `/software/components/useraccess/<id>/kerberosX/principal` :
 mandatory
 
     Principal identity for the user in the Kerberos ticket server.
 
-- `/software/components/useraccess`/<id>/kerberosX/instance :
+- `/software/components/useraccess/<id>/kerberosX/instance` :
 optional
 
     "Instance" identity for the user. This is a sub-identity, and it's
     optional.
 
-- `/software/components/useraccess`/<id>/kerberosX/host : optional
+- `/software/components/useraccess/<id>/kerberosX/host` : optional
 
     Host from which the ticket must come for this identity. It is
     currently ignored.
@@ -281,4 +281,4 @@ with `passwd -l`. Depending on how you configured SSH, a locked user
 may still be able to log-in with his public key. You can run `ncm-ncd
 --unconfigure useraccess` to temporarily lock all accounts, before
 removing the user's entry from CDB. Or remove manually .k\*login and
-.ssh/authorized\_keys.
+.ssh/authorized_keys.

--- a/travis-build
+++ b/travis-build
@@ -2,4 +2,4 @@
 set -e # halt script on error
 
 bundle exec jekyll build
-bundle exec htmlproof ./_site
+bundle exec htmlproof --check-html ./_site


### PR DESCRIPTION
Mostly caused by our crappy old auto-generated component docs.
This is in preparation for extending the validation checks we can run with travis-ci.