### PR TITLE
add link to 16.2.0 documentation

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -9,7 +9,12 @@ This page contains high-level documentation of the core tools of the Quattor Too
 People new to Quattor should start with the "[Overview](/documentation/2012/06/19/documentation-overview.html)" and "[Getting Started](/documentation/2013/10/01/documentation-getting-started.html)" articles.
 If you don't find the documentation you need here, tell us!
 
-### Configuration Modules (Components)
+### CAF, CCM and Configuration Modules (Components)
+
+* [16.2.0](http://quattor-documentation.readthedocs.org/en/16.2.0/)
+
+### Old Configuration Modules (Components)
+
 * [15.12.0](http://quattor-core.readthedocs.org/en/15.12.0/)
 * [15.4.0](http://quattor-core.readthedocs.org/en/15.4.0/)
 * [14.10.0](http://quattor-core.readthedocs.org/en/14.10.0/)


### PR DESCRIPTION
Adds the link for the 16.2.0 documentation. 
It has:
 - configuration-modules-core documentation
 - configuration-modules-grid schema's
 - CAF
 - CCM

For next release I would like a better index and add configuration-modules-grid. 