### PR TITLE
Remove 'Historical Wiki' from menu

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -3,5 +3,4 @@
   <li><a href="{{ site.baseurl }}/documentation/">Documentation</a></li>
   <li><a href="{{ site.baseurl }}/contacts/">Contacts</a></li>
   <li><a href="{{ site.baseurl }}/downloads/">Downloads</a></li>
-  <li><a href="https://trac.lal.in2p3.fr/Quattor/wiki/">Historical wiki</a></li>
 </ul>


### PR DESCRIPTION
The information on the historical wiki is now mostly obsolete, better no to point users to it!