### PR TITLE
link to 16.6.0 documentation

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -11,6 +11,7 @@ If you don't find the documentation you need here, tell us!
 
 ### CAF, CCM and Configuration Modules (Components)
 
+* [16.6.0](http://quattor-documentation.readthedocs.org/en/16.6.0/)
 * [16.2.0](http://quattor-documentation.readthedocs.org/en/16.2.0/)
 
 ### Old Configuration Modules (Components)


### PR DESCRIPTION
needs https://github.com/quattor/documentation/pull/2 merged and built in readthedocs.