### PR TITLE
Fixes for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.3.1
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <title>Quattor | {{ page.title }}</title>
-  <base href="{{ site.baseurl }}/" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% feed_meta %}
   <link rel="stylesheet" type="text/css" href="/bootstrap/css/bootstrap.min.css" media="screen" />

--- a/_posts/2009-03-11-workshop.md
+++ b/_posts/2009-03-11-workshop.md
@@ -888,7 +888,7 @@ Continous build: suggest moving to system like Hudson
 Coding standards and development guidelines
 
 -   Good documents from Luis but nothing to enforce them
--   Should start at running \[<http://perlcritic.com> Perl::Critic\]:
+-   Should start at running Perl::Critic:
     highly configurable, large set of code checks, possibility to
     include project specific requirements
 


### PR DESCRIPTION
Newer versions of activesupport now require ruby 2.2 or newer.
Github pages is using ruby 2.3.1.