### PR TITLE
Replace dead link with last web archive copy

### DIFF
--- a/_posts/2006-03-22-workshop.md
+++ b/_posts/2006-03-22-workshop.md
@@ -300,7 +300,7 @@ Andago plans to develop components for several services.
 
 -   Many have to be written from scratch (http, anti-spam, MySQL…)
 
-1st release of TOMAS planned 31st of May. <http://tomas.andago.com>
+1st release of TOMAS planned 31st of May. [http://tomas.andago.com](https://web.archive.org/web/20070604144357/http://tomas.andago.com/mediawiki/index.php/Main_Page)
 (<jgato@andago.com>)
 
 ## CDB / SCDB Status and Directions
@@ -826,7 +826,7 @@ Quattor : quattor conventions (schema…) : quattor/
 
 ## TOMAS3 - R. Garcia Leiva
 
-<http://tomas.andago.com>
+[http://tomas.andago.com](https://web.archive.org/web/20070604144357/http://tomas.andago.com/mediawiki/index.php/Main_Page)
 
 Andago : company targeted at providing solutions for Linux based on open
 source technologies.
@@ -983,4 +983,3 @@ A Quattor release should be only the core components, not the templates
     the mailing list.
 -   No consensus on entering something into Savanah for every change (at
     least tag) to CVS. Another option is to improve quattor build tools.
-


### PR DESCRIPTION
Page hasn't been reachable since 2007, but might be of historical interest (maybe), so at least provide an archived copy.