### PR TITLE
add a link to the 16.10 docs

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -11,6 +11,7 @@ If you don't find the documentation you need here, tell us!
 
 ### CAF, CCM and Configuration Modules (Components)
 
+* [16.10.0](http://quattor-documentation.readthedocs.org/en/16.10.0/)
 * [16.6.0](http://quattor-documentation.readthedocs.org/en/16.6.0/)
 * [16.2.0](http://quattor-documentation.readthedocs.org/en/16.2.0/)
 


### PR DESCRIPTION
requires https://github.com/quattor/documentation/pull/6 to be merged and tagged.