### PR TITLE
Change category of London Workshop to Meeting

### DIFF
--- a/_posts/2016-10-04-london-workshop.md
+++ b/_posts/2016-10-04-london-workshop.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: Summary of 22nd Quattor workshop (2016-10-04 to 2016-10-06, London)
-category: news
+category: meeting
 author: Michel Jouvin
 ---
 


### PR DESCRIPTION
The October 2016 London Workshop summary was in the 'News' category
whereas all previous workshop summaries have the category of 'meeting'.