### PR TITLE
Add a file to declare URL to ignore in html-proofer tests

### DIFF
--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+usage () {
+    echo "usage: $(basename $0) [--debug]"
+    exit 2
+}
+
+debug_option=
+
+if [ "$1" == "--debug" ]
+then
+    debug_option="--log-level debug"
+elif [ -n "$1" ]
+then
+    echo "Unsupported option ($1)"
+    usage
+fi
+
+url_ignore_file=$(dirname $0)/url-ignore
+if [ ! -f ${url_ignore_file} ]
+then
+    echo "List of URL to ignore must exist (${url_ignore_file}), even if empty"
+    exit 1
+fi
+
+url_ignore_patterns=
+url_ignore_option=
+# The following construct ensure that the end line is processed if not ending by \n
+while IFS='' read -r url || [[ -n "$url" ]]; do
+    url=$(echo ${url} | sed -e 's/\s*#.*$//')
+    if [ -n "${url}" ]
+    then
+        url=$(echo ${url} | sed -e 's%/%\\/%g' -e 's/\./\\./g' -e 's/\?/\\?/')
+        url_ignore_patterns="${url_ignore_patterns},/${url}/"
+    fi
+done < "${url_ignore_file}"
+url_ignore_patterns=$(echo "${url_ignore_patterns}" | sed -e 's/^,//')
+if [ -n "${url_ignore_patterns}" ]
+then
+    url_ignore_option="--url-ignore ${url_ignore_patterns}"
+fi
+echo "html-proofer url-ignore option: ${url_ignore_option}"
+
+bundle exec jekyll build
+set +e # do not halt script on error
+bundle exec htmlproofer ${url_ignore_option} ${debug_option} --check-html ./_site
+status=$?
+if [ ${status} -ne 0 -a -z "${debug_option}" ]
+then
+    echo ""
+    echo "htmlproofer failed to validate site contents: use --debug for more information"
+fi
+
+exit ${status}

--- a/.travis-scripts/url-ignore
+++ b/.travis-scripts/url-ignore
@@ -1,0 +1,13 @@
+# List of URL to ignore in html-proofer external link check
+# One URL per line, comments allowed as a full line or after the URL.
+# There is only a limited support for URL regexp rather than plain
+# URL : use a regexp only if it is really necessary. But the URL
+# may be a partial URL (ommitting the protocol for example or the
+# end of the URL).
+#
+# Please, DO NOT PUT BROKEN URLs in this file. Only add URLs that
+# cannot be verified successfully by html-proofer despite you
+# validated them with a browser.
+
+indico.desy.de/conferenceOtherViews.py
+http://sonarqube.com      # SonarQube

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-script: ./travis-build
+script: ./.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:

--- a/travis-build
+++ b/travis-build
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-bundle exec htmlproofer --url-ignore "/indico.desy.de\/conferenceOtherViews.py/" --check-html ./_site


### PR DESCRIPTION
This PR moves the `travis-script` script in `.travis-scripts/html-proofer`  and adds a list of URL to exclude in the checks maintained as a separate file (rather than an inline list of url patterns in the script).