### PR TITLE
Update Jekyll and Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-cache: bundler
+cache:
+  bundler: true
+  directories:
+  - $TRAVIS_BUILD_DIR/tmp/.htmlproofer # See https://github.com/gjtorikian/html-proofer/issues/381
+
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev # required to avoid SSL errors
 
 sudo: false

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ kramdown:
   input: GFM
   hard_wrap: false
 exclude: [vendor]
-gems:
+plugins:
   - jekyll-feed
   - jekyll-redirect-from
 collections:


### PR DESCRIPTION
The `gems` option has been renamed to `plugins` - update our config to reflect this and remove the warning message on builds.
Cache html-proofer files - this should result in faster builds that throw fewer spurious http errors.