### PR TITLE
travis: Update environment to allow spellchecker to run

### DIFF
--- a/.travis-scripts/spellchecker
+++ b/.travis-scripts/spellchecker
@@ -8,7 +8,13 @@ tar -xvzf spellchecker.tar.gz
 
 cp -f .travis-scripts/dictionary.txt markdown-spellchecker-$SCVERSION/src/dict.txt
 
+echo
+echo spellchecker config:
+echo --------------------
 cat markdown-spellchecker-$SCVERSION/src/config.ini
+echo --------------------
+echo
 
-git diff --name-only HEAD^ | grep '\.md$' | xargs -r markdown-spellchecker-$SCVERSION/src/spellchecker.py || exit 1
-
+pyenv local 3.5
+pip3 install pyenchant
+git diff --name-only HEAD^ | grep '\.md$' | xargs -r python3.5 markdown-spellchecker-$SCVERSION/src/spellchecker.py || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: ruby
+
 rvm:
 - 2.3.1
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install python3-enchant
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
@@ -29,6 +26,8 @@ cache:
 addons:
   apt:
     packages:
+    - python3-enchant # Won't be used, but pulls in required system dependencies for version from PIP
     - libcurl4-openssl-dev # required to avoid SSL errors
 
-sudo: required
+sudo: false
+dist: trusty


### PR DESCRIPTION
Update environment to allow spellchecker to run

* Switch to Trusty based containers
* Install enchant library
* Set Python 3.5 with pyenv
* Install pyenchant module against Python 3.5

Fixes #229.