### PR TITLE
TravisCI: Fix build environment

### DIFF
--- a/.travis-scripts/spellchecker
+++ b/.travis-scripts/spellchecker
@@ -15,6 +15,7 @@ cat markdown-spellchecker-$SCVERSION/src/config.ini
 echo --------------------
 echo
 
-pyenv local 3.5
+pyenv versions
+pyenv local 3.6
 pip3 install pyenchant
 git diff --name-only HEAD^ | grep '\.md$' | xargs -r python3.5 markdown-spellchecker-$SCVERSION/src/spellchecker.py || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 
 rvm:
-- 2.3.1
+- 2.4.2
+
+before_install: gem install bundler # update bundler.
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
 
 before_install: gem install bundler # update bundler.
 
+before_script: bundle update github-pages
+
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,9 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "jekyll"
-gem "jekyll-redirect-from"
-gem "html-proofer", "~> 3"
+gem 'github-pages', '>= 175'
 gem 'jekyll-feed'
-gem "github-pages"
+gem 'jekyll-redirect-from'
+gem 'html-proofer', '~> 3'
 
 # Suggested by Jekyll
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
-

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,7 +16,7 @@
           <p>
             Quattor is developed as a community effort and provided as <strong><a href="https://github.com/quattor/">open-source software</a></strong>
             under the <strong><a href="http://opensource.org/licenses/Apache-2.0">Apache 2.0 license</a></strong> and
-            <a href="http://opensource.org/licenses/eudatagrid.php">EU DataGrid Software License</a>.
+            <a href="https://opensource.org/licenses/EUDatagrid">EU DataGrid Software License</a>.
           </p>
         </div>
 


### PR DESCRIPTION
Travis has updated to images based on Ubuntu's Trusty release and moved quite a few things around in the process, we've also let our versions drift behind [what GitHub is using to build pages](https://pages.github.com/versions/) which has caused build breakage.