### PR TITLE
Remove dead link to WallStreetTech

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -34,7 +34,7 @@
           <div class="col-md-3">
             <h2>Scalable</h2>
             <p>Enterprise for everyone.</p>
-            <p>Proven in academic and commercial environments, managing infrastructures ranging from tens of systems to <a href="http://www.wallstreetandtech.com/it-infrastructure/216402934">over 30000</a>. </p>
+            <p>Proven in academic and commercial environments, managing infrastructures ranging from tens of systems to over 30000. </p>
           </div>
           <div class="col-md-3">
             <h2>Accurate</h2>


### PR DESCRIPTION
There is an archived version of the page at https://web.archive.org/web/20170206145904/http://www.wallstreetandtech.com:80/infrastructure/morgan-stanley-growing-its-use-of-linux/d/d-id/1261644, but it doesn't seem worth preserving the link.