### PR TITLE
Aquilon documentation improvements

### DIFF
--- a/.travis-scripts/dictionary.txt
+++ b/.travis-scripts/dictionary.txt
@@ -7,16 +7,19 @@ bashism
 Bruxelles
 CAF
 CCM
+CentOS
 Ceph
 config
 cron
 devel
+DHCP
 DNS
 DPM
 EL
 EPEL
 formatter
 FreeIPA
+fullname
 Gabor
 Ganesha
 gerrit
@@ -27,10 +30,14 @@ GPFS
 GPG
 GPU
 GPUs
+GRN
+GRNs
 hacky
 HEPiX
 init
 INSTALLDIR
+IP
+IPMI
 IPv
 jrha
 JSON
@@ -44,7 +51,10 @@ logstash
 Maven
 metaconfig
 metadata
+middleware
+NIC
 noarch
+NTP
 OneFlow
 OpenNebula
 OpenStack
@@ -69,6 +79,7 @@ RPM
 RPMs
 rsyslog
 scalability
+SCDB
 SELinux
 SQL
 SQLite
@@ -79,14 +90,17 @@ symlink
 systemd
 th
 UGent
+UMD
 unconfigured
 urbonegi
 unsynchronized
 VirtualEnv
 virtualenv
+VLAN
 VM
 VMs
 whitespace
+workflow
 
 # Workaround for issue https://github.com/stfc/markdown-spellchecker/issues/9
 # Remove when it is fixed
@@ -96,5 +110,8 @@ endcomment
 FIXME
 freenode
 html
+hw
 md
+proofer
+py
 tl

--- a/.travis-scripts/dictionary.txt
+++ b/.travis-scripts/dictionary.txt
@@ -4,13 +4,18 @@ API
 aquilon
 Aquilon
 bashism
+bootable
 Bruxelles
 CAF
 CCM
 CentOS
 Ceph
+compilable
+Compilable
 config
 cron
+CVE
+CVEs
 devel
 DHCP
 DNS
@@ -59,6 +64,8 @@ OneFlow
 OpenNebula
 OpenStack
 org
+pakiti
+Pakiti
 panc
 Perl
 Postgres
@@ -66,6 +73,7 @@ postgres
 PostgreSQL
 postgresql
 PowerDNS
+predeployment
 protobuf
 PyPI
 quattor
@@ -94,6 +102,7 @@ UMD
 unconfigured
 urbonegi
 unsynchronized
+versioned
 VirtualEnv
 virtualenv
 VLAN

--- a/_aquilon/00-install.md
+++ b/_aquilon/00-install.md
@@ -15,7 +15,7 @@ The instruction below describes how to install Aquilon from the sources and run 
 of the installation steps described here require that you can become `root` on the machine. The configuration of a
 site with Aquilon is covered in a [specific page][aquilon_configuration].
 
-*Note: the commands provided in this documentation are intended to be copy/pasted.*
+**Note: the commands provided in this documentation are intended to be copy/pasted.**
 
 ## Install Required Packages
 

--- a/_aquilon/00-install.md
+++ b/_aquilon/00-install.md
@@ -432,12 +432,6 @@ To start the production broker, a systemd unit file must be added. A template is
 `/opt/aquilon/etc/systemd/aquilon-broker.service`. Review its contents, in particular the
 Python interpreter path, before copying the file to `/etc/systemd/system/multi-user.target.wants`.
 
-{% comment %}
-FIXME: remove this note once the PR has been merged
-{% endcomment %}
-*Note: if `/opt/aquilon/etc/systemd/aquilon-broker.service` doesn't exist, you may have to
-retrieve it from [GitHub pull request](https://github.com/quattor/aquilon/pull/75).*
-
 The aquilon broker service relies on `/etc/sysconfig/aqd` for its configuration. Create it from
 the template in `/opt/aquilon/etc/sysconfig/aqd`, changing `TWISTD` to `/opt/aquilon/sbin/aqd.py` and ensuring
 that other variables have a definition consistent with what is in `/etc/aqd.conf`.

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -637,6 +637,13 @@ variable HOSTNAME = hostname_from_object();
 variable DOMAIN = domain_from_object('no.default');
 variable FULL_HOSTNAME= OBJECT;
 
+# Network parameters are defined by the Aquilon broker
+final variable NETWORK_PARAMS = {
+    SELF['ip'] = value('/system/network/primary_ip');
+    SELF['gateway'] = value('/system/network/default_gateway');
+    SELF;
+};
+
 # Define the nameservers to use for the site.
 variable NAMESERVERS = list("192.168.1.250", "192.168.1.250");
 
@@ -814,24 +821,6 @@ unique template ${template};
 # at a later stage, thus they are marked final
 
 final variable NODE_OS_VERSION = 'el7.x-x86_64';
-
-final variable OS_VERSION_PARAMS = {
-    SELF['majorversion'] = '7';
-    SELF['minor'] = 'x';
-    SELF['distribution'] = 'el';
-    SELF['family'] = 'el';
-    SELF['major'] = SELF['distribution'] + SELF['majorversion'];
-    SELF['arch'] = 'x86_64';
-    SELF['flavour'] = 'x';
-    SELF['version'] = 'el7x';
-    SELF;
-};
-
-final variable NETWORK_PARAMS = {
-    SELF['ip'] = value('/system/network/primary_ip');
-    SELF['gateway'] = value('/system/network/default_gateway');
-    SELF;
-};
 
 include 'os/config/declarations';
 include 'config/core/base';

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -686,6 +686,10 @@ variable YUM_SNAPSHOT_DATE ?= '20180409';
 # Must match the first part of the YUM repository actual name
 variable YUM_OS_DISTRIBUTION_NAME ?= 'centos7';
 
+# Timezone definition until the broker put it in the plenary templates
+# See https://github.com/quattor/aquilon/issues/91
+variable TIMEZONE ?= 'US/Pacific';
+
 # Load Quattor profile schema
 include 'quattor/profile_base';
 
@@ -776,12 +780,11 @@ cat > web_servers/archetype/final.pan <<EOF
 unique template archetype/final;
 
 # AII (initial installation) configuration
-include 'config/quattor/aii';               # provided by OS templates
 variable AII_OSINSTALL_EXTRAPKGS ?= list();
-#variable AII_OS_INSTALL_OPTION_TIMEZONE = "your timezone";
-#'/system/timezone' = TIMEZONE;
+variable AII_OSINSTALL_OPTION_TIMEZONE = TIMEZONE;
 
 # Must be included after AII_OSINSTALL_EXTRAPKGS is populated
+include "config/quattor/aii";           # Part of the OS templates
 include "quattor/aii/config";
 
 # Configure YUM repositories

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -635,7 +635,7 @@ variable OS_CORE_POSTFIX ?= true;
 # Define some variable used on many templates based on the current object template
 variable HOSTNAME = hostname_from_object();
 variable DOMAIN = domain_from_object('no.default');
-variable FULL_HOSTNAME= full_hostname_from_object(DOMAIN);
+variable FULL_HOSTNAME= OBJECT;
 
 # Define the nameservers to use for the site.
 variable NAMESERVERS = list("192.168.1.250", "192.168.1.250");

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -47,7 +47,7 @@ These are the basic terms in Aquilon operations:
 * `domain`: A set of shared Quattor templates. Entities to be
   configured live in exactly one domain. A domain is currently
   implemented as a branch in the template-king git repository.
-* `feature`: A re-useable configuration template that configures a
+* `feature`: A reuseable configuration template that configures a
   specific thing but does not in itself describe a complete
   system. A feature may be included in
   a personality or anywhere else that PAN template code can be
@@ -137,7 +137,7 @@ aq add_archetype --archetype web_servers --compilable
 The template library is a set of generic templates that
 help to build host descriptions. It provides many building blocks, in particular
 `features` and hardware-related templates, ready to use to configure the host hardware,
-standardOS services and a few more specific
+standard OS services and a few more specific
 middleware, like [OpenStack](https://www.openstack.org) for clouds or
 [UMD](https://wiki.egi.eu/wiki/Middleware){:data-proofer-ignore=""}
 for grid.
@@ -265,7 +265,7 @@ aq add_machine --machine testhw --model thegreatserver --rack ${rackid}
 
 Each machine has a number of network interfaces, with their MAC
 addresses.  They need to be added to the machine object previously created. Aquilon
-supports different types of interfaces (public, management, vlan...): see `aq help add_interface`
+supports different types of interfaces (public, management, VLAN...): see `aq help add_interface`
 for details. The MAC address can be explicitly defined for a standard machine or auto-generated
 for a virtual machine. The interface can belong to a port group. One of the interface must be
 marked as `bootable` to be able to define an IP address when adding the host.

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -165,8 +165,9 @@ directory rather than in the `template-king` Git repository.
 
 A template library version is enabled in the context of an archetype, using `archetype/declarations.pan`
 This template is typically placed in the archetype directory for which you want to enable this version
-of the template library. Currently, we'll add it to the plenary templates area, under
-`/var/quattor/cfg/plenary/web_servers`, where `web_servers` is the archetype we'll use in our examples.
+of the template library. Temporarily, for the purposes of this tutorial, we'll add it to the plenary 
+templates area, under `/var/quattor/cfg/plenary/web_servers`, where `web_servers` is the 
+archetype we'll use in our examples.
 
 The typical contents for `declarations.pan` can be created with:
 
@@ -390,9 +391,10 @@ echo "structure template ${template};" > ${template_file}
 
 ### Creating the archetype/base and archetype/final templates
 
-Aquilon requires 2 templates for each archetype, located in the `archetype`
-directory under the directory corresponding to the archetype,
-`/var/quattor/cfg/plenary/web_servers` in our example:
+In addition to the declarations.pan template described above,  each archetype requires 2 
+further templates located in a directory called `<<name-of-archetype>>/archetype`,
+in our example `web_servers/archetype`, in the plenary template area,
+`/var/quattor/cfg/plenary`:
 
 * `base.pan`: this template is the first executed template after the definition of the hardware.
 * `final.pan`: it will be the very last one executed in the host profile. It will be
@@ -910,7 +912,9 @@ Personality configuration consists mainly of adding or removing features to it w
 
 ### Adding a feature to test personality
 
-In our example, we will add the feature `pakiti` to the personality `test` used with the host
+In our example, we will add the feature 
+[pakiti](https://github.com/quattor/template-library-standard/tree/master/features/pakiti)) 
+to the personality `test` used with the host
 `testsrv.dailyplanet.com`. [Pakiti](https://github.com/CESNET/pakiti-server) is a service to collect and
 display the patch status of hosts against known CVEs. Its configuration is part of the template library,
 meaning that we don't need to write the Pan templates associated with the feature.
@@ -918,13 +922,24 @@ meaning that we don't need to write the Pan templates associated with the featur
 The `pakiti` feature is easily added to the Aquilon database with:
 
 ```bash
-aq add feature --feature pakiti --type host --actation dispatch --deactivation reboot --grn test
+aq add feature --feature pakiti --type host --activation dispatch --deactivation reboot \
+               --grn test --comment "This feature deploys de Pakiti software"
 ```
+
+`--comment` is optional but it is a good practice to use it to describe what the feature does.
 
 Once added it must be bound to the `web-servers` personality:
 
 ```bash
-aq bind_feature --feature pakity --personality test --archetype web_servers
+aq bind_feature --feature pakiti --personality test --archetype web_servers
+```
+
+After modifying a personality and before promoting the new configuration as the current
+one, it is possible to see the differences between the current and the new configuration with
+`aq show_diff`:
+
+```bash
+aq show_diff --archetype web_servers --personality test --personality_stage current --other_stage next
 ```
 
 The resulting new personality configuration must now be promoted as `current` so that `testsrv.dailyplanet.com`
@@ -947,7 +962,6 @@ variable PAKITI_SERVER ?= 'pakiti.dailyplanet.com';
 The new host configuration can now be compiled, published an deployed with the usual commands:
 
 ```bash
-aq promote --personality test --archetype web_servers
 aq reconfigure --hostname testsrv.dailyplanet.com
 aq publish --branch tutorial
 aq deploy --source tutorial --target test

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -161,18 +161,18 @@ directory rather than in the `template-king` Git repository.
 
 ### Enabling the Template Library
 
-A template library version is enabled in the context of an archetype, using `archetype/loadpath.pan`
+A template library version is enabled in the context of an archetype, using `archetype/declarations.pan`
 This template is typically placed in the archetype directory for which you want to enable this version
 of the template library. Currently, we'll add it to the plenary templates area, under
 `/var/quattor/cfg/plenary/web_servers`, where `web_servers` is the archetype we'll use in our examples.
 
-* Create the `loadpath.pan` template directory:
+* Create the `declarations.pan` template directory:
 
     ```bash
     mkdir -p /var/quattor/cfg/plenary/web_servers/archetype
     ```
 
-* Create the `/var/quattor/cfg/plenary/web_servers/archetype/loadpath.pan` template with the following content:
+* Create the `/var/quattor/cfg/plenary/web_servers/archetype/declarations.pan` template with the following content:
 
 ```pan
 # It is VERY IMPORTANT not to use this template for anything else than the initial
@@ -182,7 +182,7 @@ of the template library. Currently, we'll add it to the plenary templates area, 
 # be a declaration template because any change to / will be removed by a subsequent
 # line in the object template.
 
-declaration template archetype/loadpath;
+declaration template archetype/declarations;
 
 # Replace by the template library version you want to use
 final variable QUATTOR_RELEASE = '18.3.0';
@@ -831,19 +831,19 @@ final variable NETWORK_PARAMS = {
     SELF;
 };
 
-include 'os/config/loadpath';
+include 'os/config/declarations';
 include 'config/core/base';
 EOF
 ```
 
 This template is calling a template independent of the particular OS name and version to
 add to the `LOADPATH` the template library for the selected OS version. In the example,
-this template is called `os/config/loadpath.pan` (in the archetype directory, i.e.
-`web_servers/os/config/loadpath.pan`). A typical content for this template is;
+this template is called `os/config/declarations.pan` (in the archetype directory, i.e.
+`web_servers/os/config/declarations.pan`). A typical content for this template is;
 
 ```bash
 cd /var/quattor/templates/$USER/tutorial/web_servers
-template=os/config/loadpath
+template=os/config/declarations
 template_ns=$(dirname ${template})
 template_file=${template}.pan
 mkdir -p ${template_ns}

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -49,7 +49,7 @@ These are the basic terms in Aquilon operations:
 * `domain`: A set of shared Quattor templates. Entities to be
   configured live in exactly one domain. A domain is currently
   implemented as a branch in the template-king git repository.
-* `feature`: A reuseable configuration template that configures a
+* `feature`: A reusable configuration template that configures a
   specific thing but does not in itself describe a complete
   system. A feature may be included in
   a personality or anywhere else that PAN template code can be
@@ -61,7 +61,7 @@ These are the basic terms in Aquilon operations:
   external source such as the Aquilon database.
 * `sandbox`: A development area for making changes to Pan
   templates. Each sandbox must be started from a domain and hosts or
-  clusters may be managed into the sandbox to allow for pre-deployment
+  clusters may be managed into the sandbox to allow for predeployment
   testing. Once the template code is fully tested, it must be
   published back to the broker and then deployhttp://quattor-pan.readthedocs.org/en/latested to the shared domain.
 * `service`: A network-based service with well-known clients and

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -930,7 +930,13 @@ The `pakiti` feature is easily added to the Aquilon database with:
 aq add feature --feature pakiti --type host --actation dispatch --deactivation reboot --grn test
 ```
 
-The new personality configuration must now be promoted as `current` so that `testsrv.dailyplanet.com`
+Once added it must be bound to the `web-servers` personality:
+
+```bash
+aq bind_feature --feature pakity --personality test --archetype web_servers
+```
+
+The resulting new personality configuration must now be promoted as `current` so that `testsrv.dailyplanet.com`
 can use the updated personality:
 
 ```bash

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -833,6 +833,17 @@ aq deploy --source test --target prod
 aq manage --hostname preprodsrv.dailyplanet.com --domain prod
 ```
 
+## Defining the Personality
+
+Personality configuration is *staged*. That means that when a personality is updated, the change is not
+visible to the hosts using it until it is promoted as the `current` version with the `aq promote` command.
+When a personality is created and when it is updated, its stage is defined to `next` (configuration that
+will be applied to the personality when the new configuration is promoted as the production (`current`) one.
+
+Personality configuration consists mainly of adding or removing features to it with the
+`aq update_personoality` command. More details can be found in the documentation on
+[advanced management][aquilon_management] tasks, in particular the section related to features.
+
 ## Troubleshooting
 
 ### Error "branch already exists" when creating a domain

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -1,8 +1,10 @@
 ---
 layout: article
 title: Starting a Site with Aquilon
-author: Luis Fernando Muñoz Mejías
-menu: Using Aquilon
+author: 
+  - Luis Fernando Muñoz Mejías
+  - Michel Jouvin
+menu: Starting with Aquilon
 redirect_from: /documentation/2013/10/25/aquilon-site.html
 ---
 

--- a/_aquilon/configuration.md
+++ b/_aquilon/configuration.md
@@ -166,15 +166,11 @@ This template is typically placed in the archetype directory for which you want 
 of the template library. Currently, we'll add it to the plenary templates area, under
 `/var/quattor/cfg/plenary/web_servers`, where `web_servers` is the archetype we'll use in our examples.
 
-* Create the `declarations.pan` template directory:
+The typical contents for `declarations.pan` can be created with:
 
-    ```bash
-    mkdir -p /var/quattor/cfg/plenary/web_servers/archetype
-    ```
-
-* Create the `/var/quattor/cfg/plenary/web_servers/archetype/declarations.pan` template with the following content:
-
-```pan
+```bash
+mkdir -p /var/quattor/cfg/plenary/web_servers/archetype
+cat > web_servers/archetype/declarations.pan <<EOF
 # It is VERY IMPORTANT not to use this template for anything else than the initial
 # LOADPATH configuration.
 #
@@ -191,6 +187,7 @@ variable LOADPATH = append(SELF, format('template-library/%s/core', QUATTOR_RELE
 variable LOADPATH = append(SELF, format('template-library/%s/standard', QUATTOR_RELEASE));
 
 variable DEBUG = debug(format('%s: (template=%S) LOADPATH=%s', OBJECT, TEMPLATE, to_string(LOADPATH)));
+EOF
 ```
 
 

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -148,6 +148,38 @@ git commit -m 'Add features demon and rootpasswd'
 git push
 ```
 
+### Binding features to personalities and archetypes
+
+A feature can be bound to one or more personalities or archetypes. It means that all using these
+personalities or archetypes will have the feature configured. The command to do it is
+`aq bind_feature`. For example to bind the feature `demo` created previously to the personality `test`,
+the command would be:
+
+```bash
+aq bind_feature --feature demo --personality test --archetype web_servers
+```
+
+To bind it to the `web_servers` archetype (i.e. whatever archetype personality is used),
+the commad variant is:
+
+```bash
+aq bind_feature --feature demo --archetype web_servers
+```
+
+### Defining the new personality configuration as current
+
+Personality configuration is *staged*. That means that when a personality is updated, the change is not
+visible to the hosts using it until it is promoted as the `current` version with the `aq promote` command.
+When a personality is created and when it is updated, its stage is defined to `next` (configuration that
+will be applied to the personality when the new configuration is promoted as the production (`current`) one.
+
+With our previous example, to use the updated personality configuration for the hosts having this personality,
+use the following command:
+
+```bash
+aq promote --personality test --archetype web_servers
+```
+
 ## Networks
 
 ### How to define the routers for my networks?

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -238,6 +238,36 @@ If you need an external network, you have to create it with
 `--network_environment external` in its command line.
 
 
+## Implementing Modifications in the Template Library
+
+The [template library][tl_intro] provides the base templates for configuring the host operating system and
+some features, in particular for OpenStack cloud and for UMD grid middleware. It has been designed to
+highly configurable without any modification, using variables. The templates are developed by the
+Quattor community. They help to lower the management effort required at each site.
+
+The template library is not intended to be modified directly by a site. This is the reason it is
+part of the plenary templates that are not visible to Aquilon users and that they are not versioned.
+See the [dedicated section][aquilon_tl] for more information on how to integrate the template
+library into Aquilon.
+
+It may happen that some of the templates need to be enhanced or that a site develops a new feature 
+that may be useful to other sites. In this case, it is recommended to create at the top level of
+the site templates a `template-library` directory. In this directory, create a sub-directory whose
+name is the template library version the modification apply to. This is the same directory structure
+as the one used in the plenary templates.
+
+Then for each template that you need to modify or add, place it in the same directory as it would be
+in the template library: the site version will be used instead of the standard one, without any modification
+to the other templates.
+
+When a new version of the template library is released, it is easy to compare the new templates with
+the local modifications to decide what still needs to be ported to the new version, using the same approach
+(a directory corresponding to the new version).
+
+It is important to submit your modification upstream, using GitHub pull requests against the relevant
+repositories. Avoid submitting one big pull request with all your changes: prefer submitting one
+pull request per change set.
+
 ## Implementing Peer-Review and Quality Assessment with Aquilon
 
 Implementing a stage deployment workflow, Aquilon makes easy to validate changes through peer-review and

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -1,8 +1,8 @@
 ---
 layout: article
-title: Aquilon Management Workflow and Advanced Topics
+title: Site Management Workflow and Operations
 author: Michel Jouvin
-menu: Management Workflow
+menu: Using Aquilon
 ---
 
 {% include link_definitions.md %}

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -167,7 +167,8 @@ highly recommended not to do it.*
 Personality configuration is *staged*. That means that when a personality is updated, the change is not
 visible to the hosts using it until it is promoted as the `current` version with the `aq promote` command.
 When a personality is created and when it is updated, its stage is defined to `next` (configuration that
-will be applied to the personality when the new configuration is promoted as the production (`current`) one.
+will be applied to the personality when the new configuration is promoted as the production (`current`) one. 
+After `aq promote` the previously current personality configuration becomes `previous`.
 
 With our previous example, to use the updated personality configuration for the hosts having this personality,
 use the following command:

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -148,10 +148,10 @@ git commit -m 'Add features demon and rootpasswd'
 git push
 ```
 
-### Binding features to personalities and archetypes
+### Binding features to personalities
 
-A feature can be bound to one or more personalities or archetypes. It means that all using these
-personalities or archetypes will have the feature configured. The command to do it is
+A feature can be bound to one or more personalities. It means that all using these
+personalities will have the feature configured. The command to do it is
 `aq bind_feature`. For example to bind the feature `demo` created previously to the personality `test`,
 the command would be:
 
@@ -159,12 +159,8 @@ the command would be:
 aq bind_feature --feature demo --personality test --archetype web_servers
 ```
 
-To bind it to the `web_servers` archetype (i.e. whatever archetype personality is used),
-the command variant is:
-
-```bash
-aq bind_feature --feature demo --archetype web_servers
-```
+*Note: despite the command help mentions that features can also be bound to archetypes, it is
+highly recommended not to do it.*
 
 ### Defining the new personality configuration as current
 

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -104,6 +104,15 @@ Aquilon. For example, you could create an archetype for all your IPMI hardware.
 aq add_archetype --archetype 'ipmi' --nocompilable
 ```
 
+## Adding New Hardware Models
+
+Arbitrary hardware components (disks, NIC, machine...) can be used to describe machines in the
+Aquilon database. But to be usable in host profiles, they have to be backed by Pan templates.
+This section requires what you need to do if you want to use
+hardware components with no template already existing in the [template library][tl_intro]. Once
+you have validated the new hardware templates, it is a good practice to request their addition to
+the template library so that other Aquilon sites can benefit from them.
+
 ## Defining New Features
 
 ### Adding a feature

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -162,7 +162,12 @@ aq bind_feature --feature demo --personality test --archetype web_servers
 *Note: despite the command help mentions that features can also be bound to archetypes, it is
 highly recommended not to do it.*
 
-### Defining the new personality configuration as current
+
+## Personalities
+
+Personalities are used to define the list of features that are configured on a host. Every host has one
+personality and only one but it is possible to change the personality of a host. Personalities are attached
+to one archetype (an archetype can be viewed as a group of possible personalities).
 
 Personality configuration is *staged*. That means that when a personality is updated, the change is not
 visible to the hosts using it until it is promoted as the `current` version with the `aq promote` command.
@@ -170,12 +175,27 @@ When a personality is created and when it is updated, its stage is defined to `n
 will be applied to the personality when the new configuration is promoted as the production (`current`) one. 
 After `aq promote` the previously current personality configuration becomes `previous`.
 
-With our previous example, to use the updated personality configuration for the hosts having this personality,
+Unlike features, personalities are entirely defined in the Aquilon database (there
+is no additional site template to create).
+
+### Defining the new personality configuration as current
+
+Based on the feature example above, to use the updated personality configuration for the hosts having this personality,
 use the following command:
 
 ```bash
 aq promote --personality test --archetype web_servers
 ```
+
+### Changing the host personality
+
+To change the personality of an existing host, use `aq reconfigure`:
+
+```bash
+aq reconfigure --hostname your_host --personality new_personality [--archetype new_archetype]
+```
+
+`--archetype` is necessary only if the new personality is not attached to the same archetype.
 
 ## Networks
 

--- a/_aquilon/management.md
+++ b/_aquilon/management.md
@@ -31,7 +31,7 @@ aq update_realm --realm dailyplanet.com --trusted
 ### Add an Aquilon user
 
 A sandbox is associated with an Aquilon user. The Aquilon user is associated with an existing Linux account
-via the `uid` and `gid` but doesn't have to be Aquilon user name doesn't have to match the Linux userid.
+via the `uid` and `gid` but doesn't have to be Aquilon user name doesn't have to match the Linux user ID.
 It must be created with the `aq add_user` command if the user doesn't exist already. To list existing
 users, use:
 
@@ -61,7 +61,7 @@ aq add_sandbox --sandbox site-init
 ```
 
 Once the sandbox is created, it is necessary to associate the host we want to manage with the
-sandbox. In all the Aquilon commands requiring a `--sandbox` option (except the `xxx_sandbox` comands),
+sandbox. In all the Aquilon commands requiring a `--sandbox` option (except the `xxx_sandbox` commands),
 the sandbox name is `user/sandbox`.
 
 ```bash
@@ -160,7 +160,7 @@ aq bind_feature --feature demo --personality test --archetype web_servers
 ```
 
 To bind it to the `web_servers` archetype (i.e. whatever archetype personality is used),
-the commad variant is:
+the command variant is:
 
 ```bash
 aq bind_feature --feature demo --archetype web_servers

--- a/_aquilon/zz-contributing.md
+++ b/_aquilon/zz-contributing.md
@@ -39,3 +39,13 @@ Short summary of the change
 Change-Id: I9f8d7d0f656e72877c436727d0e4a8d8a62a4b89
 ```
 
+## Contributing your Changes
+
+Once you have validated your changes and edited the appropriate commit messages, you need to open a pull request
+against the relevant Aquilon repository on GitHub. There are two repositories:
+
+- [Aquilon](https://github.com/quattor/aquilon) itself (the main one)
+- Aquilon [protocols](https://github.com/quattor/aquilon-protocols): Python modules used to interface to the database
+
+*Note: each commit **must** have a different `Change-ID`, even they are part of the same pull request*
+

--- a/_includes/link_definitions.md
+++ b/_includes/link_definitions.md
@@ -2,6 +2,7 @@
 This file contains link definitions that can be used in reference links.
 {% endcomment %}
 
+[aquilon_add_hw]: /aquilon/management.html#adding-new-hardware-models
 [aquilon_archetypes]: /aquilon/technical_details.html#archetypes
 [aquilon_configuration]: /aquilon/configuration.html
 [aquilon_details]: /aquilon/technical_details.html

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -19,7 +19,7 @@
           <dl class="dl-horizontal">
             {% if page.date and page.is_post %}<dt>Written</dt><dd class="date">{{ page.date | date: "%d %B %Y" }}</dd>{% endif %}
             {% if page.modified and page.is_post %}<dt>Updated</dt><dd class="date">{{ page.modified | date: "%d %B %Y"}}</dd>{% endif %}
-            {% if page.author %}<dt>Author</dt><dd class="author">{{ page.author }}</dd>{% endif %}
+            {% if page.author %}<dt>Author{% if page.author.last != page.author.first %}s{% endif %}</dt><dd class="author">{{ page.author | join: ', ' }}</dd>{% endif %}
           </dl>
           <hr>
       </div>


### PR DESCRIPTION
- Configuration: add a section on how to do the actual configuration of a host with the template library
  - Includes typical content for the main site templates needed
- Configuration tutorial reviewed and fixed after an actual execution!
- Spelling mistakes fixed

**Final content must be adjusted after #87 has been finalized**