### PR TITLE
spellchecker script: fix typo

### DIFF
--- a/.travis-scripts/spellchecker
+++ b/.travis-scripts/spellchecker
@@ -27,7 +27,7 @@ then
     commit_range=${TRAVIS_COMMIT_RANGE}
     echo "Checking modified MD files in commit range ${commit_range}..."
 else
-    oommit_range="HEAD^"
+    commit_range="HEAD^"
     echo "Checking modified MD files in last commit..."
 fi
 


### PR DESCRIPTION
Fix typo spotted by https://github.com/stdweird/quattor.github.com/pull/2#discussion_r204661930 after the merge of #253.