### PR TITLE
Fix a wrong link to Quattor ReadTheDocs in an old post

### DIFF
--- a/_posts/2015-09-22-textrender-outside-metaconfig.md
+++ b/_posts/2015-09-22-textrender-outside-metaconfig.md
@@ -299,7 +299,7 @@ because it has impact on the whole authentication system. In particular, enablin
 is done with the `authconfig` tool (which involves a lot more than simply enabling/disabling the `sssd`
 daemon).
 
-[ncm_authconfig]: http://docs-test-comps.readthedocs.org/en/latest/components/authconfig/
+[ncm_authconfig]: https://quattor-documentation.readthedocs.io/en/stable/components/authconfig/
 [sssd]: https://fedorahosted.org/sssd/
 
 ## Component


### PR DESCRIPTION
Move in a separate PR a problem originally fixed as part of #259 but independent of it and affecting any new PR for the web site.