### PR TITLE
Add information on running tests with docker/podman

### DIFF
--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -44,7 +44,8 @@ echo "html-proofer url-ignore option: ${url_ignore_option}"
 
 bundle exec jekyll build
 set +e # do not halt script on error
-bundle exec htmlproofer ${url_ignore_option} ${debug_option} --check-html ./_site
+# ignore 429 return code (too many requests)
+bundle exec htmlproofer --http_status_ignore 429 ${url_ignore_option} ${debug_option} --check-html ./_site
 status=$?
 if [ ${status} -ne 0 -a -z "${debug_option}" ]
 then

--- a/_development/00-basics.md
+++ b/_development/00-basics.md
@@ -52,6 +52,7 @@ Lots of good introductions and tutorials using Git and GitHub already exists, fo
    * Do not push to `upstream`
 7. Run the unit tests
    * Add new ones to cover your changes (or refine existing ones)
+   * [More information on running the tests](/development/unittests.html#running-the-tests)
 8. Open a pull request (PR)
    * Meaningful title; title will be part of the release notes
      * For `configuration-modules` repository: start the title with the component that is being modified

--- a/_development/unittests.md
+++ b/_development/unittests.md
@@ -26,6 +26,26 @@ that have a line number in them, are from the templated files (so there's some o
 
 If you want to run a single unit test, add `-Dunittest=name_of_test.t` to the `mvn` command line.
 
+## Container-based tests
+
+Some repositories include a `Dockerfile` to run the tests (for example `configuration-modules-core`). This makes
+it pretty easy to get a test environment. The following examples are using podman instead of docker on a
+recent Fedora. They should be run from the root directory of the repository:
+
+- First build the container:
+```
+podman build -t quattor_testing -f Dockerfile .
+```
+This uses the current 'master' of `template-library-core` so you need to rebuild the container if you need a newer version.
+
+- To run all tests using the current (changed) repository:
+```
+podman run -it --user=$(id -ur):$(id -gr) --userns=keep-id -v $PWD:/quattor_test:z localhost/quattor_testing
+```
+The `--user` and `--userns` options are to make sure the test run as your user inside the container. To run specific
+test, you can pass the `MVN_ARGS` variable: `-e MVN_ARGS="-Dunittest=00-tqu.t -pl ncm-systemd"`.
+
+
 ## Logging
 
 If you want more logging, you can set `-Dprove.args=-v` (the `verbose` flag of `prove`)


### PR DESCRIPTION
As suggested in https://github.com/quattor/configuration-modules-core/pull/1464

Please have a look @ned21 