### PR TITLE
Remove Ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-ruby "~> 3"
 gem 'html-proofer', '~> 4'


### PR DESCRIPTION
As noted in #277 this appears to cause GitHub Pages to throw a warning.