### PR TITLE
github/workflows: Prefer latest v1 release of setup-ruby

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Ruby
-      uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
         ruby-version: '3.1'


### PR DESCRIPTION
The commit we have been using up until now doesn't support the current runner images.